### PR TITLE
budget item typeを追加する

### DIFF
--- a/app/graphql/types/budget_item_kind_type.rb
+++ b/app/graphql/types/budget_item_kind_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class BudgetItemKindType < Types::BaseEnum
+    value "FIXED", value: "fixed"
+    value "VARIABLE", value: "variable"
+    value "INVESTMENTS", value: "investments"
+    value "SAVING", value: "saving"
+  end
+end

--- a/app/graphql/types/budget_item_kind_type.rb
+++ b/app/graphql/types/budget_item_kind_type.rb
@@ -2,9 +2,8 @@
 
 module Types
   class BudgetItemKindType < Types::BaseEnum
-    value "FIXED", value: "fixed"
-    value "VARIABLE", value: "variable"
-    value "INVESTMENTS", value: "investments"
-    value "SAVING", value: "saving"
+    BudgetItem.kinds.keys.each do |kind|
+      value kind.upcase, value: kind
+    end
   end
 end

--- a/app/graphql/types/budget_item_type.rb
+++ b/app/graphql/types/budget_item_type.rb
@@ -4,7 +4,7 @@ module Types
   class BudgetItemType < Types::BaseObject
     field :id, ID, null: false
     field :name, String, null: false
-    field :kind, Integer, null: false
+    field :kind, Types::BudgetItemKindType, null: false
     field :amount, Integer, null: false
     field :bank_account_id, Integer, null: false
     field :budget, Types::BudgetType, null: false

--- a/app/graphql/types/budget_item_type.rb
+++ b/app/graphql/types/budget_item_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  class BudgetItemType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :kind, Integer, null: false
+    field :amount, Integer, null: false
+    field :bank_account_id, Integer, null: false
+    field :budget_id, Integer, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/budget_item_type.rb
+++ b/app/graphql/types/budget_item_type.rb
@@ -7,7 +7,7 @@ module Types
     field :kind, Integer, null: false
     field :amount, Integer, null: false
     field :bank_account_id, Integer, null: false
-    field :budget_id, Integer, null: false
+    field :budget, Types::BudgetType, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/budget_type.rb
+++ b/app/graphql/types/budget_type.rb
@@ -6,6 +6,7 @@ module Types
     field :started_at, GraphQL::Types::ISO8601DateTime, null: false
     field :finished_at, GraphQL::Types::ISO8601DateTime, null: false
     field :amount, Integer, null: false
+    field :budget_items, [Types::BudgetItemType], null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end


### PR DESCRIPTION
- budget item typeを作成する
- budget itemのenum用に kind typeを作成する
  - ⚠️ enumの文字列には、マルチバイト文字を設定できない模様 🤔 
- 以下のようなクエリでリクエストする
  ```
  query {
    budget(id: 1) {
      id
      startedAt
      finishedAt
      amount
      budgetItems {
        id
        name
        kind
        amount
        bankAccountId
      }
    }
  }
  ```

- 以下のレスポンスを受け取る

```
{
  "data": {
    "budget": {
      "id": "1",
      "startedAt": "2023-09-01T00:00:00Z",
      "finishedAt": "2023-09-30T23:59:59Z",
      "amount": 475980,
      "budgetItems": [
        {
          "id": "1",
          "name": "予算アイテム1",
          "kind": "FIXED",
          "amount": 1,
          "bankAccountId": 1
        }
      ]
    }
  }
}
```

